### PR TITLE
Fix drawing explicit function when zoomed range is very small

### DIFF
--- a/ScatterDraw/ScatterDraw.cpp
+++ b/ScatterDraw/ScatterDraw.cpp
@@ -1757,10 +1757,9 @@ Vector<Pointf> ScatterDraw::DataAddPoints(DataSource& data, bool primaryY, bool 
 				points << Pointf(GetPosX(xx), GetPosY(yy, primaryY));
 		}
 	} else if (data.IsExplicit()) {
-		double xmin = xMin - 1;
-		double xmax = xMin + xRange + 1;
-		double dx = (xmax - xmin)/plotW;
-		for (double xx = xmin; xx < xmax; xx += dx) {
+		double xmax = xMin + xRange;
+		double dx = xRange/plotW;
+		for (double xx = xMin - dx; xx < xmax + dx; xx += dx) {
 			double yy = data.f(xx);
 			if (!IsNum(yy))
 				points << Null;


### PR DESCRIPTION
When zoomed range size is very small, the number of points when value of function is calculated is wrong. We expect that value of function should be computed at every pixel of x-axis plus one on the left and one on the right. This pull request make changes to achieve that behaviour.