### PR TITLE
Fix infinite loop on very large zoom for explicit functions

### DIFF
--- a/ScatterDraw/ScatterDraw.cpp
+++ b/ScatterDraw/ScatterDraw.cpp
@@ -1757,9 +1757,9 @@ Vector<Pointf> ScatterDraw::DataAddPoints(DataSource& data, bool primaryY, bool 
 				points << Pointf(GetPosX(xx), GetPosY(yy, primaryY));
 		}
 	} else if (data.IsExplicit()) {
-		double xmax = xMin + xRange;
 		double dx = xRange/plotW;
-		for (double xx = xMin - dx; xx < xmax + dx; xx += dx) {
+		for (int i = -1; i <= plotW; i++) {
+			double xx = xMin + dx * i;
 			double yy = data.f(xx);
 			if (!IsNum(yy))
 				points << Null;


### PR DESCRIPTION
When graph is zoomed on x axis to a non-zero number, adding dx in the loop can be void due to arithmetic underflow which leads to the infinite loop. The loop is rewritten.